### PR TITLE
Replaced removed opencv constants, removed DataLoaderUSCHair.cxx from sources for no-torch build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,6 @@ set(MY_SRC
     ${PROJECT_SOURCE_DIR}/src/DataLoaderLLFF.cxx
     #fb
     ${PROJECT_SOURCE_DIR}/src/fb/DataLoaderBlenderFB.cxx
-    ${PROJECT_SOURCE_DIR}/src/fb/DataLoaderUSCHair.cxx
 )
 set(DEPS_SRC
     ${PROJECT_SOURCE_DIR}/deps/json11/json11.cpp

--- a/src/DataLoaderColmap.cxx
+++ b/src/DataLoaderColmap.cxx
@@ -308,14 +308,14 @@ void DataLoaderColmap::read_data(){
 
 
 
-      cv::cvtColor(frame.rgb_8u, frame.gray_8u, CV_BGR2GRAY);
+      cv::cvtColor(frame.rgb_8u, frame.gray_8u, cv::COLOR_BGR2GRAY);
       frame.rgb_8u.convertTo(frame.rgb_32f, CV_32FC3, 1.0/255.0);
       // cv::cvtColor(frame.rgb_32f, frame.gray_32f, CV_BGR2GRAY);
       frame.width=frame.rgb_32f.cols;
       frame.height=frame.rgb_32f.rows;
 
       //load gradients
-      cv::cvtColor(frame.rgb_32f, frame.gray_32f, CV_BGR2GRAY);
+      cv::cvtColor(frame.rgb_32f, frame.gray_32f, cv::COLOR_BGR2GRAY);
       cv::Scharr( frame.gray_32f, frame.grad_x_32f, CV_32F, 1, 0);
       cv::Scharr( frame.gray_32f, frame.grad_y_32f, CV_32F, 0, 1);
 

--- a/src/DataLoaderImg.cxx
+++ b/src/DataLoaderImg.cxx
@@ -332,7 +332,7 @@ void DataLoaderImg::read_data_for_cam(const int cam_id){
             // std::cout << "copying into the frame rgba yields " << type2string(frame.rgba.type()) << '\n';
 
             // //gray
-            cv::cvtColor ( frame.rgb_32f, frame.gray_32f, CV_BGR2GRAY );
+            cv::cvtColor ( frame.rgb_32f, frame.gray_32f, cv::COLOR_BGR2GRAY);
             // frame.gray.convertTo(frame.gray, CV_32F, 1.0/255.0);
             // if(!m_only_rgb || !frame.distort_coeffs.isZero() ){
             //     frame.gray=undistort_image(frame.gray, frame.K, frame.distort_coeffs, cam_id); //undistort only the gray image because rgb is only used for visualization

--- a/src/DataLoaderLLFF.cxx
+++ b/src/DataLoaderLLFF.cxx
@@ -261,7 +261,7 @@ void DataLoaderLLFF::read_data(){
 
 
 
-        cv::cvtColor(frame.rgb_8u, frame.gray_8u, CV_BGR2GRAY);
+        cv::cvtColor(frame.rgb_8u, frame.gray_8u, cv::COLOR_BGR2GRAY);
         frame.rgb_8u.convertTo(frame.rgb_32f, CV_32FC3, 1.0/255.0);
         // cv::cvtColor(frame.rgb_32f, frame.gray_32f, CV_BGR2GRAY);
         frame.width=frame.rgb_32f.cols;

--- a/src/DataLoaderStanford3DScene.cxx
+++ b/src/DataLoaderStanford3DScene.cxx
@@ -213,7 +213,7 @@ void DataLoaderStanford3DScene::read_sample(Frame& frame_color, Frame& frame_dep
     //read depth
     std::string rgb_name = sample_filename.filename().string();
     std::string depth_path = (sample_filename.parent_path().parent_path()/"depth"/rgb_name).string();
-    cv::Mat depth=cv::imread(depth_path, CV_LOAD_IMAGE_ANYDEPTH);
+    cv::Mat depth=cv::imread(depth_path, cv::IMREAD_ANYDEPTH);
     if(m_depth_subsample_factor>1){
         cv::Mat resized;
         cv::resize(depth, resized, cv::Size(), 1.0/m_depth_subsample_factor, 1.0/m_depth_subsample_factor, cv::INTER_NEAREST);

--- a/src/DataLoaderVolRef.cxx
+++ b/src/DataLoaderVolRef.cxx
@@ -276,7 +276,7 @@ void DataLoaderVolRef::read_sample(Frame& frame_color, Frame& frame_depth, const
 
     //read depth
     std::string name = sample_filename.string().substr(0, sample_filename.string().size()-9); //removes the last 5 characters corresponding to "color"
-    cv::Mat depth=cv::imread(name+"depth.png", CV_LOAD_IMAGE_ANYDEPTH);
+    cv::Mat depth=cv::imread(name+"depth.png", cv::IMREAD_ANYDEPTH);
     if(m_depth_subsample_factor>1){
         cv::Mat resized;
         cv::resize(depth, resized, cv::Size(), 1.0/m_depth_subsample_factor, 1.0/m_depth_subsample_factor, cv::INTER_NEAREST);

--- a/src/fb/DataLoaderBlenderFB.cxx
+++ b/src/fb/DataLoaderBlenderFB.cxx
@@ -525,7 +525,7 @@ void DataLoaderBlenderFB::load_images_in_frame(easy_pbr::Frame& frame){
 
     rgb_32f=rgb_32f*m_exposure_change;
     frame.rgb_32f= rgb_32f;
-    cv::cvtColor(frame.rgb_32f, frame.gray_32f, CV_BGR2GRAY);
+    cv::cvtColor(frame.rgb_32f, frame.gray_32f, cv::COLOR_BGR2GRAY);
 
     frame.width=frame.rgb_32f.cols;
     frame.height=frame.rgb_32f.rows;


### PR DESCRIPTION
I replaced multiple occurrences of the constants CV_LOAD_IMAGE_ANYDEPTH and CV_BGR2GRAY with cv::IMREAD_ANYDEPTH and cv::COLOR_BGR2GRAY respectively to enable compatibility with OpenCV 4, since those were removed. The new constants are already available in OpenCV 3, so it should still be compatible.

Also, the CMakeList had DataLoaderUSCHair.cxx listed as source file even if no torch is available, which prevented successful compilation in that case, so I removed that line.